### PR TITLE
ci: migrate workflows to P6M_-prefixed platform secret/variable names (YP6M-2545)

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -15,10 +15,10 @@ jobs:
   build_and_deploy:
     uses: ./.github/workflows/build_docker_container.yml
     secrets:
-      ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-      ARTIFACTORY_IDENTITY_TOKEN: ${{ secrets.ARTIFACTORY_IDENTITY_TOKEN }}
-      UPDATE_MANIFEST_TOKEN: ${{ secrets.UPDATE_MANIFEST_TOKEN }}
-      ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+      ARTIFACTORY_USERNAME: ${{ secrets.P6M_ARTIFACTORY_USERNAME }}
+      ARTIFACTORY_IDENTITY_TOKEN: ${{ secrets.P6M_ARTIFACTORY_IDENTITY_TOKEN }}
+      UPDATE_MANIFEST_TOKEN: ${{ secrets.P6M_UPDATE_MANIFEST_TOKEN }}
+      ARTIFACTORY_TOKEN: ${{ secrets.P6M_ARTIFACTORY_TOKEN }}
     with:
       ARTIFACTORY_REGISTRY: "p6m.jfrog.io"
       APPS: data-transforms-library 

--- a/.github/workflows/build_docker_container.yml
+++ b/.github/workflows/build_docker_container.yml
@@ -44,10 +44,10 @@ on:
         type: string
 
 env:
-  ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-  ARTIFACTORY_IDENTITY_TOKEN: ${{ secrets.ARTIFACTORY_IDENTITY_TOKEN }}
-  UPDATE_MANIFEST_TOKEN: ${{ secrets.UPDATE_MANIFEST_TOKEN }}
-  ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+  ARTIFACTORY_USERNAME: ${{ secrets.P6M_ARTIFACTORY_USERNAME }}
+  ARTIFACTORY_IDENTITY_TOKEN: ${{ secrets.P6M_ARTIFACTORY_IDENTITY_TOKEN }}
+  UPDATE_MANIFEST_TOKEN: ${{ secrets.P6M_UPDATE_MANIFEST_TOKEN }}
+  ARTIFACTORY_TOKEN: ${{ secrets.P6M_ARTIFACTORY_TOKEN }}
   ARTIFACTORY_REGISTRY: ${{ inputs.ARTIFACTORY_REGISTRY }}
   INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
@@ -80,7 +80,7 @@ jobs:
       - name: Install dependencies
         run: |
           poetry --version
-          poetry config http-basic.${{ inputs.ORG_NAME }}_${{ inputs.VENTURE_NAME }}_pypi_local  ${{ secrets.ARTIFACTORY_USERNAME }}  ${{ secrets.ARTIFACTORY_IDENTITY_TOKEN }}
+          poetry config http-basic.${{ inputs.ORG_NAME }}_${{ inputs.VENTURE_NAME }}_pypi_local  ${{ secrets.P6M_ARTIFACTORY_USERNAME }}  ${{ secrets.P6M_ARTIFACTORY_IDENTITY_TOKEN }}
           poetry install --verbose
 
       - name: Setup Node
@@ -121,7 +121,7 @@ jobs:
       - name: Publish to Private PyPI
         run: |
           poetry version ${{ steps.TAG.outputs.value }}
-          poetry --build publish -r ${{ inputs.ORG_NAME }}_${{ inputs.VENTURE_NAME }}_pypi_push -u ${{ secrets.ARTIFACTORY_USERNAME }} -p ${{ secrets.ARTIFACTORY_IDENTITY_TOKEN }}
+          poetry --build publish -r ${{ inputs.ORG_NAME }}_${{ inputs.VENTURE_NAME }}_pypi_push -u ${{ secrets.P6M_ARTIFACTORY_USERNAME }} -p ${{ secrets.P6M_ARTIFACTORY_IDENTITY_TOKEN }}
 
       - name: Prepare Artifact
         run: |


### PR DESCRIPTION
## What

Migrate every `.github/workflows/**` reference from legacy platform-managed secret/variable names to their `P6M_`-prefixed twins. Part of the **ybor-playground** org sweep (YP6M-2545) under YP6M-1711.

## Why

Dual-emit is live on control-plane-prd — the github-operator emits **both** the legacy and `P6M_` org secret/variable names today. This rename is a no-op at runtime and prepares the org for legacy retirement (YP6M-2406).

## Changes

`secrets.<LEGACY>` → `secrets.P6M_<LEGACY>` and `vars.<LEGACY>` → `vars.P6M_<LEGACY>` for the in-scope platform names (`ARTIFACTORY_*`, `PLATFORM_DISPATCH_URL`, `UPDATE_MANIFEST_TOKEN`, `REPOSITORY_PUSH_TOKEN`, `SUBGRAPH_PULL_TOKEN`). Reusable-workflow **input keys** are unchanged — only the caller's own `secrets`/`vars` resolution flips. `secrets.GITHUB_TOKEN` (GitHub built-in) is untouched.

## Validation

`P6M_` org twins are confirmed to resolve on control-plane-prd — pilot run on `example-dotnet-rest-service` had `.NET` + Docker `Login Succeeded` with the renamed creds, and all repos share the same org-level secrets. Per-repo build CI runs on merge to `main`.

**Tooling**

| Skills Used | Agents Used |
|-------------|-------------|
| `ybor-standards:git` | `ybor-standards:cli-explorer` |
| `ybor-standards:git-branch-start` | `Claude Opus 4.8 (1M context)` |
| `ybor-standards:git-commit` | |
| `ybor-standards:git-pr-create` | |
